### PR TITLE
Upgrade Improvements

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -1,3 +1,3 @@
 [user]
-        name = Kong - Jenkins
-        email = office@konghq.com
+name = Kong - Jenkins
+email = office@konghq.com

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,6 @@ jobs:
       with:
         files: |
           ./docker-bake.hcl
-        targets: build
     - name: Release
       id: release
       uses: ahmadnassri/action-semantic-release@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,4 +56,3 @@ jobs:
         files: |
           ./docker-bake.hcl
           ${{ steps.meta.outputs.bake-file }}
-        targets: build

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,10 @@ ENV INITRD No
 COPY executors.groovy /usr/share/jenkins/ref/init.groovy.d/executors.groovy
 RUN echo 2.0 > /usr/share/jenkins/ref/jenkins.install.UpgradeWizard.state
 
+# set to any string to skip s3 skip in entrypoint.sh
+ARG SKIP_S3
+ENV SKIP_S3=
+
 COPY entrypoint.sh /entrypoint.sh
 COPY .gitconfig /root/.gitconfig
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ COPY entrypoint.sh /entrypoint.sh
 COPY .gitconfig /root/.gitconfig
 
 COPY --chown=jenkins:jenkins plugins.txt /usr/share/jenkins/ref/plugins.txt
-RUN jenkins-plugin-cli -f /usr/share/jenkins/ref/plugins.txt
+RUN jenkins-plugin-cli --verbose -f /usr/share/jenkins/ref/plugins.txt
 
 RUN set -ex; \
     apt-get update -y -qq && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,10 +7,6 @@ ENV INITRD No
 COPY executors.groovy /usr/share/jenkins/ref/init.groovy.d/executors.groovy
 RUN echo 2.0 > /usr/share/jenkins/ref/jenkins.install.UpgradeWizard.state
 
-# set to any string to skip s3 skip in entrypoint.sh
-ARG SKIP_S3
-ENV SKIP_S3=${SKIP_S3}
-
 COPY entrypoint.sh /entrypoint.sh
 COPY .gitconfig /root/.gitconfig
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM jenkins/jenkins:2.346.2@sha256:da871f844343306a0557363e858036acbe3f5016622eb2c9ff0c8bfd8c0edfcf
+FROM jenkins/jenkins:2.347@sha256:24118114fa3235905fce84748b630e72f4c8bcd2b2881f2bc16199e19ff4ecc7
 
 USER root
 ENV DEBIAN_FRONTEND noninteractive

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,13 @@ COPY .gitconfig /root/.gitconfig
 COPY --chown=jenkins:jenkins plugins.txt /usr/share/jenkins/ref/plugins.txt
 RUN jenkins-plugin-cli -f /usr/share/jenkins/ref/plugins.txt
 
-RUN apt-get update && apt-get install -qy python3-pip groff-base
-RUN pip install awscli
+RUN set -ex; \
+    apt-get update -y -qq && \
+    apt-get install -y -qq \
+        wget unzip && \
+    cd /tmp && \
+    wget -nv "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" && \
+    unzip -q awscli-*.zip && \
+    ./aws/install && aws --version
 
 CMD /bin/bash /entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,7 @@ RUN jenkins-plugin-cli --verbose -f /usr/share/jenkins/ref/plugins.txt
 
 RUN set -ex; \
     apt-get update -y -qq && \
-    apt-get install -y -qq \
-        wget unzip && \
+    apt-get install -y -qq wget unzip && \
     cd /tmp && \
     wget -nv "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" && \
     unzip -q awscli-*.zip && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN echo 2.0 > /usr/share/jenkins/ref/jenkins.install.UpgradeWizard.state
 
 # set to any string to skip s3 skip in entrypoint.sh
 ARG SKIP_S3
-ENV SKIP_S3=
+ENV SKIP_S3=${SKIP_S3}
 
 COPY entrypoint.sh /entrypoint.sh
 COPY .gitconfig /root/.gitconfig

--- a/README.md
+++ b/README.md
@@ -10,3 +10,19 @@ Jenkins.instance.pluginManager.plugins.each{
     println ("${plugin.getShortName()}:${plugin.getVersion()}")
 }
 ```
+
+## Local Builds
+
+```bash
+docker buildx bake --set default.tags=kong/jenkins -f docker-bake.hcl
+```
+
+### Skip S3 sync
+
+It may be desirable to skip the `aws s3 sync ...` portion of `entrypoint.sh` when building locally.
+
+The default value of `SKIP_S3` causes the skip to NOT skip this command.
+
+```bash
+docker buildx bake --set default.tags=kong/jenkins --set default.args.SKIP_S3=true -f docker-bake.hcl
+```

--- a/README.md
+++ b/README.md
@@ -16,13 +16,3 @@ Jenkins.instance.pluginManager.plugins.each{
 ```bash
 docker buildx bake --set default.tags=kong/jenkins -f docker-bake.hcl
 ```
-
-### Skip S3 sync
-
-It may be desirable to skip the `aws s3 sync ...` portion of `entrypoint.sh` when building locally.
-
-The default value of `SKIP_S3` causes the skip to NOT skip this command.
-
-```bash
-docker buildx bake --set default.tags=kong/jenkins --set default.args.SKIP_S3=true -f docker-bake.hcl
-```

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,6 +1,6 @@
 target "docker-metadata-action" {}
 
-target "build" {
+target "default" {
   inherits = ["docker-metadata-action"]
   context = "./"
   dockerfile = "Dockerfile"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,11 +2,7 @@
 
 set -e
 
-if [ -n "${SKIP_S3:-}" ]; then
-  echo "skipping s3 sync"
-else
-  aws s3 sync s3://kong-aws-ecs-jenkins/.ssh /root/.ssh
-fi
+aws s3 sync s3://kong-aws-ecs-jenkins/.ssh /root/.ssh
 
 chmod 500 /root/.ssh/id_rsa
 git config --global user.name "Kong - Jenkins"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,11 @@
 
 set -e
 
-aws s3 sync s3://kong-aws-ecs-jenkins/.ssh /root/.ssh
+if [ -n "${SKIP_S3:-}" ]; then
+  echo "skipping s3 sync"
+else
+  aws s3 sync s3://kong-aws-ecs-jenkins/.ssh /root/.ssh
+fi
 
 chmod 500 /root/.ssh/id_rsa
 git config --global user.name "Kong - Jenkins"


### PR DESCRIPTION
Does a couple of things:
- Jenkins `2.347` (instead of `2.346.2`)
- Update the readme for building locally
- Use the `docker buildx bake` "default" target